### PR TITLE
Support port ranges in security groups

### DIFF
--- a/security_group.tf
+++ b/security_group.tf
@@ -25,7 +25,11 @@ resource "aws_security_group_rule" "custom_ports" {
   type = "ingress"
   protocol = "tcp"
   security_group_id = "${aws_security_group.sg.id}"
-  from_port = "${element(var.in_open_ports, count.index)}"
-  to_port = "${element(var.in_open_ports, count.index)}"
+  from_port = "${2 == length(split("-", element(var.in_open_ports, count.index))) ?
+      element(split("-", element(var.in_open_ports, count.index)), 0) :
+      element(var.in_open_ports, count.index) }"
+  to_port = "${2 == length(split("-", element(var.in_open_ports, count.index))) ?
+      element(split("-", element(var.in_open_ports, count.index)), 1) :
+      element(var.in_open_ports, count.index) }"
   cidr_blocks = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
Open ports can be now specified both as "80" for single ports and as
"8001-8008" for port ranges.

## test plan

The following config:

```
  in_open_ports   = ["80", "8001-8008"]
```

Produces the following plan:

```
...
  + module.cranehost.aws_security_group_rule.custom_ports[0]
      id:                                        <computed>
      cidr_blocks.#:                             "1"
      cidr_blocks.0:                             "0.0.0.0/0"
      from_port:                                 "80"
      protocol:                                  "tcp"
      security_group_id:                         "${aws_security_group.sg.id}"
      self:                                      "false"
      source_security_group_id:                  <computed>
      to_port:                                   "80"
      type:                                      "ingress"

  + module.cranehost.aws_security_group_rule.custom_ports[1]
      id:                                        <computed>
      cidr_blocks.#:                             "1"
      cidr_blocks.0:                             "0.0.0.0/0"
      from_port:                                 "8001"
      protocol:                                  "tcp"
      security_group_id:                         "${aws_security_group.sg.id}"
      self:                                      "false"
      source_security_group_id:                  <computed>
      to_port:                                   "8008"
      type:                                      "ingress"

...
```