### PR TITLE
Inherit provider settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = "${var.region}"
-}
-
 data "aws_ami" "ami" {
   most_recent = true
   owners = ["099720109477"]

--- a/variables.tf
+++ b/variables.tf
@@ -11,10 +11,6 @@ variable ami {
   default = ""
 }
 
-variable region {
-  default = "eu-west-1"
-}
-
 variable volume_size {
   description = "Volume size"
   default = 8


### PR DESCRIPTION
Inherit provider settings (including region) from parent module.

See: https://www.terraform.io/docs/modules/usage.html#implicit-provider-inheritance