### PR TITLE
#5: Update to terraform 0.12

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -7,6 +7,6 @@ output "ssh_cmd" {
 }
 
 output "public_ip" {
-  value = "${aws_instance.instance.public_ip}"
+  value = aws_instance.instance.public_ip
 }
 

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,35 +1,34 @@
 resource "aws_security_group" "sg" {
-  name = "${var.project_name}"
+  name = var.project_name
 }
 
 resource "aws_security_group_rule" "ssh" {
-  type = "ingress"
-  protocol = "tcp"
-  security_group_id = "${aws_security_group.sg.id}"
-  from_port = 22
-  to_port = 22
-  cidr_blocks = "${var.in_cidr_blocks}"
+  type              = "ingress"
+  protocol          = "tcp"
+  security_group_id = aws_security_group.sg.id
+  from_port         = 22
+  to_port           = 22
+  cidr_blocks       = var.in_cidr_blocks
 }
 
 resource "aws_security_group_rule" "out_all" {
-  type = "egress"
-  protocol = -1
-  security_group_id = "${aws_security_group.sg.id}"
-  from_port = 0
-  to_port = 0
-  cidr_blocks = ["0.0.0.0/0"]
+  type              = "egress"
+  protocol          = -1
+  security_group_id = aws_security_group.sg.id
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "custom_ports" {
-  count = "${length(var.in_open_ports)}"
-  type = "ingress"
-  protocol = "tcp"
-  security_group_id = "${aws_security_group.sg.id}"
-  from_port = "${2 == length(split("-", element(var.in_open_ports, count.index))) ?
-      element(split("-", element(var.in_open_ports, count.index)), 0) :
-      element(var.in_open_ports, count.index) }"
-  to_port = "${2 == length(split("-", element(var.in_open_ports, count.index))) ?
-      element(split("-", element(var.in_open_ports, count.index)), 1) :
-      element(var.in_open_ports, count.index) }"
-  cidr_blocks = "${var.in_cidr_blocks}"
+  count             = length(var.in_open_ports)
+  type              = "ingress"
+  protocol          = "tcp"
+  security_group_id = aws_security_group.sg.id
+  from_port         = 2 == length(split("-", element(var.in_open_ports, count.index))) ? element(split("-", element(var.in_open_ports, count.index)), 0) : element(var.in_open_ports, count.index)
+
+  to_port = 2 == length(split("-", element(var.in_open_ports, count.index))) ? element(split("-", element(var.in_open_ports, count.index)), 1) : element(var.in_open_ports, count.index)
+
+  cidr_blocks = var.in_cidr_blocks
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,63 +1,63 @@
-variable project_name {
+variable "project_name" {
   description = "Project name, used for namespacing things"
 }
 
-variable instance_type {
+variable "instance_type" {
   default = "t2.micro"
 }
 
-variable ami {
+variable "ami" {
   description = "Custom AMI, if empty will use latest Ubuntu"
   default     = ""
 }
 
-variable volume_size {
+variable "volume_size" {
   description = "Volume size"
   default     = 8
 }
 
-variable ssh_private_key {
+variable "ssh_private_key" {
   description = "Used to connect to the instance once created"
 }
 
-variable ssh_key_name {
+variable "ssh_key_name" {
   description = "Name of the key-pair on EC2 (aws-ireland, buildo-aws, ...)"
 }
 
-variable zone_id {
+variable "zone_id" {
   description = "Route53 Zone ID"
 }
 
-variable host_name {
+variable "host_name" {
   description = "DNS host name"
 }
 
-variable quay_password {
+variable "quay_password" {
   description = "Quay password"
 }
 
-variable init_script {
-  description = "bash code executed before `crane lift` is called, example: `\"${file(\"init.sh\")}\"`"
+variable "init_script" {
+  description = "bash code executed before `crane lift` is called, example: `\"$${file(\\\"init.sh\\\")}\"`"
   default     = ""
 }
 
-variable in_open_ports {
+variable "in_open_ports" {
   default = []
 }
 
-variable in_cidr_blocks {
+variable "in_cidr_blocks" {
   default = ["0.0.0.0/0"]
 }
 
-variable disk_utilization_alarm_threshold {
+variable "disk_utilization_alarm_threshold" {
   description = "disk occupation alarm threshold (% of disk utilization)"
   default     = "80"
 }
 
-variable bellosguardo_target {
+variable "bellosguardo_target" {
   description = "Possible values are 'buildo', 'omnilab'"
 }
 
-variable iam_instance_profile {
+variable "iam_instance_profile" {
   default = ""
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Closes [#2520440](https://buildo.kaiten.io/space/32111/card/2520440)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #5
Closes #4

## Test Plan

### tests performed

`terraform init`
`terraform plan`

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_cloudwatch_metric_alarm.disk-full will be created
  + resource "aws_cloudwatch_metric_alarm" "disk-full" {
      + actions_enabled                       = true
      + alarm_actions                         = [
          + "arn:aws:sns:eu-west-1:309416224681:bellosguardo",
        ]
      + alarm_description                     = "This metric monitors disk utilization"
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanOrEqualToThreshold"
      + dimensions                            = (known after apply)
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 3
      + id                                    = (known after apply)
      + metric_name                           = "DiskSpaceUtilization"
      + namespace                             = "System/Linux"
      + ok_actions                            = [
          + "arn:aws:sns:eu-west-1:309416224681:bellosguardo",
        ]
      + period                                = 60
      + statistic                             = "Average"
      + threshold                             = 80
      + treat_missing_data                    = "breaching"
    }

  # aws_instance.instance will be created
  + resource "aws_instance" "instance" {
      + ami                          = "ami-09456e8683eb4d259"
      + arn                          = (known after apply)
      + associate_public_ip_address  = true
      + availability_zone            = (known after apply)
      + cpu_core_count               = (known after apply)
      + cpu_threads_per_core         = (known after apply)
      + get_password_data            = false
      + host_id                      = (known after apply)
      + id                           = (known after apply)
      + instance_state               = (known after apply)
      + instance_type                = "t2.micro"
      + ipv6_address_count           = (known after apply)
      + ipv6_addresses               = (known after apply)
      + key_name                     = "key-name"
      + outpost_arn                  = (known after apply)
      + password_data                = (known after apply)
      + placement_group              = (known after apply)
      + primary_network_interface_id = (known after apply)
      + private_dns                  = (known after apply)
      + private_ip                   = (known after apply)
      + public_dns                   = (known after apply)
      + public_ip                    = (known after apply)
      + secondary_private_ips        = (known after apply)
      + security_groups              = [
          + "sg",
        ]
      + source_dest_check            = true
      + subnet_id                    = (known after apply)
      + tags                         = {
          + "Name" = "name"
        }
      + tenancy                      = (known after apply)
      + volume_tags                  = (known after apply)
      + vpc_security_group_ids       = (known after apply)

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_interface_id  = (known after apply)
        }

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 8
          + volume_type           = (known after apply)
        }
    }

  # aws_route53_record.dns will be created
  + resource "aws_route53_record" "dns" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "name"
      + records         = (known after apply)
      + ttl             = 300
      + type            = "A"
      + zone_id         = "zone-id"
    }

  # aws_security_group.sg will be created
  + resource "aws_security_group" "sg" {
      + arn                    = (known after apply)
      + description            = "Managed by Terraform"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "name"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + vpc_id                 = (known after apply)
    }

  # aws_security_group_rule.out_all will be created
  + resource "aws_security_group_rule" "out_all" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + from_port                = 0
      + id                       = (known after apply)
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 0
      + type                     = "egress"
    }

  # aws_security_group_rule.ssh will be created
  + resource "aws_security_group_rule" "ssh" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + from_port                = 22
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 22
      + type                     = "ingress"
    }

Plan: 6 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

This plan was saved to: terraform-0.11.plan

To perform exactly these actions, run the following command to apply:
    terraform apply "terraform-0.11.plan"


```

### tests not performed (domain coverage)
`terraform apply` not performed